### PR TITLE
fix: use correct serviceAccountName in deployment

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
       annotations:
         {{ toYaml .Values.podAnnotations | nindent 8 }}
     spec:
-      serviceAccountName: {{ .Chart.Name }}
+      serviceAccountName: {{ .Release.Name }}
       containers:
         - name: switchboard
           image: {{ .Values.image.name }}:{{ .Values.image.tag }}


### PR DESCRIPTION
resolves #2 

Looks like this doesn't need anything else than the `serviceAccountName` reference change.